### PR TITLE
Update pg_query to 0.8.0

### DIFF
--- a/hsql.gemspec
+++ b/hsql.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'mustache', '> 0'
   spec.add_dependency 'activesupport', '> 0'
-  spec.add_dependency 'pg_query', '>= 0.6.4'
+  spec.add_dependency 'pg_query', '~> 0.8.0'
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rubocop', '~> 0.3'
   spec.add_development_dependency 'rake', '> 0'

--- a/spec/hsql/file_spec.rb
+++ b/spec/hsql/file_spec.rb
@@ -53,15 +53,15 @@ SQL
           'update_condition' => 'WHERE 1 <> 1',
         )
         expect(parse.queries.map(&:to_s)).to eql([
-          'INSERT INTO jackdanger_summaries SELECT * FROM interesting_information',
-          'UPDATE summaries_performed SET complete = 1 WHERE 1 <> 1',
+          'INSERT INTO "jackdanger_summaries" SELECT * FROM "interesting_information"',
+          'UPDATE "summaries_performed" SET complete = 1 WHERE 1 <> 1',
         ])
       end
     end
 
     context 'when the front matter is missing' do
       let(:file_contents) do
-        'INSERT INTO some_table SELECT * FROM interesting_information'
+        'INSERT INTO "some_table" SELECT * FROM "interesting_information"'
       end
 
       it 'throws an error' do
@@ -98,7 +98,7 @@ SQL
       let(:environment) { 'development' }
       it 'interpolates development variables' do
         expect(parse.queries.map(&:to_s).join).to match(
-          /INSERT INTO jackdanger_summaries/,
+          /INSERT INTO "jackdanger_summaries"/,
         )
       end
     end
@@ -106,7 +106,7 @@ SQL
     context 'for the production environment' do
       let(:environment) { 'production' }
       it 'interpolates production variables' do
-        expect(parse.queries.map(&:to_s).join).to match(/INSERT INTO summaries/)
+        expect(parse.queries.map(&:to_s).join).to match(/INSERT INTO "summaries"/)
       end
     end
   end

--- a/spec/hsql/query_spec.rb
+++ b/spec/hsql/query_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../lib/hsql/query'
 
 RSpec.describe HSQL::Query do
   let(:first_query) do
-    'INSERT INTO table_a (a, b) SELECT * FROM table_b'
+    'INSERT INTO "table_a" (a, b) SELECT * FROM "table_b"'
   end
   let(:sql) do
     ''"
@@ -20,9 +20,9 @@ RSpec.describe HSQL::Query do
     it 'properly understands the queries' do
       expect(parse.map(&:to_s)).to eql(
         [
-          'INSERT INTO table_a (a, b) SELECT * FROM table_b',
-          'SELECT count(*) FROM users',
-          'UPDATE factories SET x = y WHERE a = b',
+          'INSERT INTO "table_a" (a, b) SELECT * FROM "table_b"',
+          'SELECT count(*) FROM "users"',
+          'UPDATE "factories" SET x = "y" WHERE "a" = "b"',
         ],
       )
     end


### PR DESCRIPTION
A quick PR for `hsql` to stay healthy for upcoming `pg_query` changes. 🌱

pg_query `0.8.X` will be the last series with the current parse tree format (and PostgreSQL 9.4), that `hsql` depends on.

Starting with `0.9.0`, pg_query will be based on PostgreSQL 9.5, and will output a parse tree format thats closer to how Postgres stores the tree internally, but backwards incompatible.

This makes sure we're safe on the `0.8` branch (old format), and fixes the tests, since they were broken due to some small deparsing formatting changes.
